### PR TITLE
修复audio关闭连接

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/protocol/DashScopeWebSocketClient.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/protocol/DashScopeWebSocketClient.java
@@ -177,6 +177,7 @@ public class DashScopeWebSocketClient extends WebSocketListener {
 	public void onClosing(WebSocket webSocket, int code, String reason) {
 		logger.info("receive ws event onClosing: handle={}, code={}, reason={}", webSocket.toString(), code, reason);
 		emittersComplete("closing");
+		webSocket.close(code, reason);
 	}
 
 	@Override


### PR DESCRIPTION
当第一个请求结束后，空闲一段时间，服务端发送关闭连接请求，日志如下：
 [liyuncs.com/...] c.a.c.a.d.p.DashScopeWebSocketClient     : binary emitter handling: complete on closing

代码监听到后并未做关闭处理，导致链接无法关闭，下一次新的请求永远在等待过程中。
新增了一个关闭处理，本地测试正常